### PR TITLE
Replace Decodable to Himotoki.Decodable

### DIFF
--- a/Pagination/GitHubRequest.swift
+++ b/Pagination/GitHubRequest.swift
@@ -13,7 +13,7 @@ extension GitHubRequest {
     }
 }
 
-extension GitHubRequest where Response: Decodable {
+extension GitHubRequest where Response: Himotoki.Decodable {
     func response(from object: Any, urlResponse: HTTPURLResponse) throws -> Response {
         return try decodeValue(object)
     }

--- a/Pagination/PaginationResponse.swift
+++ b/Pagination/PaginationResponse.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Himotoki
 
-struct SearchResponse<Element: Decodable>: PaginationResponse {
+struct SearchResponse<Element: Himotoki.Decodable>: PaginationResponse {
     let elements: [Element]
     let page: Int
     let nextPage: Int?

--- a/Pagination/PaginationResponseType.swift
+++ b/Pagination/PaginationResponseType.swift
@@ -2,14 +2,14 @@ import Foundation
 import Himotoki
 
 protocol PaginationResponse {
-    associatedtype Element: Decodable
+    associatedtype Element: Himotoki.Decodable
     var elements: [Element] { get }
     var page: Int { get }
     var nextPage: Int? { get }
     init(elements: [Element], page: Int, nextPage: Int?)
 }
 
-struct AnyPaginationResponse<Element: Decodable>: PaginationResponse {
+struct AnyPaginationResponse<Element: Himotoki.Decodable>: PaginationResponse {
     let elements: [Element]
     let page: Int
     let nextPage: Int?

--- a/Pagination/PaginationViewModel.swift
+++ b/Pagination/PaginationViewModel.swift
@@ -5,7 +5,7 @@ import APIKit
 import Action
 import Himotoki
 
-class PaginationViewModel<Element: Decodable> {
+class PaginationViewModel<Element: Himotoki.Decodable> {
     let indicatorViewAnimating: Driver<Bool>
     let elements: Driver<[Element]>
     let loadError: Driver<Error>

--- a/Pagination/Repository.swift
+++ b/Pagination/Repository.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Himotoki
 
-struct Repository: Decodable {
+struct Repository: Himotoki.Decodable {
     let id: Int
     let fullName: String
     let stargazersCount: Int


### PR DESCRIPTION
To avoid type name collision with Foundation.Decodable in Xcode 9 or later.